### PR TITLE
Call static method with class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ class EsiIncludeWebpackPlugin {
       this.replacers = [];
       const promises = this.options.esi.map(async esiItem => {
         if (isProductionMode) {
-          this.replacers.push(this.buildEsiString(esiItem));
+          this.replacers.push(EsiIncludeWebpackPlugin.buildEsiString(esiItem));
         } else {
           const content = await this.buildFullFileInclude(esiItem);
           this.replacers.push(content);


### PR DESCRIPTION
Without this fix I get the error

```
TypeError: this.buildEsiString is not a function
    at /home/razorx/meltwater/dmi/app/node_modules/@meltwater/esi-include-webpack-plugin/src/index.js:48:36
    at Array.map (<anonymous>)
    at /home/razorx/meltwater/dmi/app/node_modules/@meltwater/esi-include-webpack-plugin/src/index.js:46:41
    at _next2 (eval at create (/home/razorx/meltwater/dmi/app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:7:17)
    at eval (eval at create (/home/razorx/meltwater/dmi/app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:24:1)
    at /home/razorx/meltwater/dmi/app/node_modules/html-webpack-plugin/index.js:290:11
```

For an explanation, see for example: https://eslint.org/docs/rules/class-methods-use-this

> Also note in the above examples that if you switch a method to a static method, instances of the class that call the static method (let a = new A(); a.sayHi();) have to be updated to being a static call (A.sayHi();) instead of having the instance of the class call the method