### PR TITLE
Fix `newHtml.replace is not a function`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,7 @@ class EsiIncludeWebpackPlugin {
   }
 
   replace(html) {
-    let newHtml = html;
+    let newHtml = html.toString();
     this.replacers.forEach(replacer => {
       // Convert search string to regex to do:
       //    - Global replace (every instance not just the first)


### PR DESCRIPTION
The source asset can be of type string as well as a Buffer.
The latter makes this plugin crash with `newHtml.replace is not a function`.
Converting the buffer to string solves the error.

It seems like `html` files that are not touched by webpack loaders are passed through as Buffers.